### PR TITLE
Add sidebar heading and date

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,18 @@
             overflow-y: auto;
             color: var(--primary-dark-text); /* Dark text for sidebar */
         }
+        .sidebar-header {
+            font-size: 1.1em;
+            font-weight: bold;
+            text-align: center;
+            margin-bottom: 15px;
+        }
+        .sidebar-footer {
+            text-align: center;
+            margin-top: 20px;
+            font-size: 0.9em;
+            color: var(--primary-medium-text);
+        }
         #sidebar ul {
             list-style: none;
             padding: 0;
@@ -927,6 +939,7 @@
 </head>
 <body>
     <div id="sidebar">
+        <div class="sidebar-header">醫學教育委員會<br>114年07月會議報告</div>
         <ul>
             <li><a href="#awards" class="sidebar-link active">頒獎</a></li>
             <li><a href="#chairman-report" class="sidebar-link">主席報告</a></li>
@@ -960,6 +973,7 @@
             <li><a href="#ad-hoc-motion" class="sidebar-link">臨時動議</a></li>
             <li><a href="#chairman-conclusion" class="sidebar-link">主席結語</a></li>
         </ul>
+        <div class="sidebar-footer">報告日期：2025/07/09</div>
     </div>
 
     <div id="content-area">


### PR DESCRIPTION
## Summary
- show a header in the sidebar for the meeting report
- display the report date at the bottom of the sidebar

## Testing
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b43d2dcb483218a5e8743ab561017