### PR TITLE
Add new teaching center links

### DIFF
--- a/index.html
+++ b/index.html
@@ -960,7 +960,7 @@
                         <a href="#teaching-center-main" class="sidebar-link sub-link">教學中心</a>
                         <ul>
                             <li><a href="#narrative-medicine-analysis" class="sidebar-link sub-link">醫院敘事醫學系列競賽活動「醫療的瞬間・永恆的感動」成果分析</a></li>
-                            <li><a href="https://qpig0218.github.io/DigitalCapability/" target="_blank" class="sidebar-link sub-link">數位賦能計畫整合藍圖</a></li>
+                            <li><a href="#digital-empowerment-blueprint" class="sidebar-link sub-link">數位賦能計畫整合藍圖</a></li>
                         </ul>
                     </li>
                     <li>
@@ -1006,6 +1006,10 @@
         <div id="teaching-center-main" class="page-content">
             <h2>教學中心</h2>
             <p>此處為教學中心的總覽頁面，請點擊左側子頁籤查看詳細報告。</p>
+            <ol class="report-list">
+                <li><a href="#narrative-medicine-analysis">醫院敘事醫學系列競賽活動「醫療的瞬間・永恆的感動」成果分析</a></li>
+                <li><a href="#digital-empowerment-blueprint">數位賦能計畫整合藍圖</a></li>
+            </ol>
         </div>
 
         <!-- 新增的教學中心子頁籤內容 -->


### PR DESCRIPTION
## Summary
- update sidebar link to "數位賦能計畫整合藍圖" to open internal page
- list teaching center items on its main page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b47109d248321ab167ac644aebbd9