### PR TITLE
Add clinical skills competition teams

### DIFF
--- a/index.html
+++ b/index.html
@@ -934,6 +934,40 @@
         .invitation-box p:last-child {
             margin-bottom: 0;
         }
+        /* Clinical Skills team blocks */
+        .clinical-team-group {
+            margin: 20px auto;
+            padding: 20px;
+            border-radius: 10px;
+            max-width: 800px;
+            box-shadow: 0 3px 10px rgba(0,0,0,0.08);
+        }
+        .clinical-team-group h3 {
+            text-align: center;
+            margin-top: 0;
+            margin-bottom: 15px;
+            color: var(--primary-dark-text);
+        }
+        .clinical-team-group ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        .clinical-team-group ul li {
+            margin-bottom: 8px;
+            font-size: 1em;
+            color: var(--primary-medium-text);
+        }
+        .clinical-team-group ul li strong {
+            color: var(--primary-dark-text);
+            margin-right: 6px;
+        }
+        .clinical-team-new {
+            background-color: #E8F5E9;
+        }
+        .clinical-team-critical {
+            background-color: #FFF3E0;
+        }
         /* Footer style */
         .page-footer {
             position: absolute;
@@ -1470,6 +1504,42 @@
                         </tbody>
                     </table>
                 </div>
+            </div>
+        </div>
+
+        <div id="clinical-skills" class="page-content">
+            <h2>2025年NCMEA國家臨床醫學教育獎擬真情境競賽參賽團隊</h2>
+
+            <div class="clinical-team-group clinical-team-new">
+                <h3>新人組</h3>
+                <ul>
+                    <li><strong>競賽日期：</strong>114年9月13日(新人組第一場) 11:55-12:40</li>
+                    <li><strong>競賽地點：</strong>林口長庚醫院</li>
+                    <li><strong>參賽人員：</strong>
+                        <ul>
+                            <li>一般科：郭家妤醫師</li>
+                            <li>急診室：鄭夙妤護理師、林美婷護理師</li>
+                            <li>急診醫學部：鄭雅云專科護理師</li>
+                        </ul>
+                    </li>
+                    <li><strong>指導教師：</strong>林昱惠醫師</li>
+                </ul>
+            </div>
+
+            <div class="clinical-team-group clinical-team-critical">
+                <h3>急重症照護組</h3>
+                <ul>
+                    <li><strong>競賽日期：</strong>114年11月15日(急重症第三場)15:35-16:45</li>
+                    <li><strong>競賽地點：</strong>高雄醫學大學附設醫院</li>
+                    <li><strong>參賽人員：</strong>
+                        <ul>
+                            <li>急診醫學部：秦郁涵醫師、陳韋廷醫師</li>
+                            <li>急診室：謝捷瀠護理師、蔡欣蓉護理師</li>
+                            <li>呼吸治療科：王盈婷小組長</li>
+                        </ul>
+                    </li>
+                    <li><strong>指導教師：</strong>蔡長志主任</li>
+                </ul>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- style: add clinical team group blocks for background colors
- content: add "臨床技能中心" page with 2025年NCMEA擬真情境競賽團隊介紹

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b4cfabbc48321834def244be6a66f