### PR TITLE
Update resident training layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,20 +412,31 @@
         }
         .summary-boxes {
             display: flex;
-            justify-content: space-around;
-            gap: 25px;
+            justify-content: space-between;
+            gap: 15px;
             margin-bottom: 40px;
             flex-wrap: nowrap; /* keep all boxes on the same row */
         }
         .summary-box {
-            background-color: var(--accent-blue-light); /* Light blue background */
             border-radius: 12px;
-            padding: 20px 25px;
-            flex: 1 0 30%;
+            padding: 15px 20px;
+            flex: 1 1 30%;
             max-width: 30%;
             box-shadow: 0 4px 15px rgba(0,0,0,0.1);
             text-align: center;
             transition: transform 0.2s ease-in-out;
+        }
+        .summary-box.established {
+            background-color: #e8f5e9; /* light green */
+            border: 2px solid var(--success-green);
+        }
+        .summary-box.planning {
+            background-color: #fff9e6; /* light yellow */
+            border: 2px solid var(--warning-yellow);
+        }
+        .summary-box.no-plan {
+            background-color: #ffe8e8; /* light red */
+            border: 2px solid var(--danger-red);
         }
         .summary-box:hover {
             transform: translateY(-5px);
@@ -441,10 +452,12 @@
         .summary-box .count {
             font-size: 3em;
             font-weight: bold;
-            color: var(--accent-blue-main); /* Blue count */
             display: block;
             margin-bottom: 10px;
         }
+        .summary-box.established .count { color: var(--success-green); }
+        .summary-box.planning .count { color: var(--warning-yellow); }
+        .summary-box.no-plan .count { color: var(--danger-red); }
         .summary-box .details {
             font-size: 1em;
             color: var(--primary-medium-text);
@@ -1388,17 +1401,17 @@
 
                 <h3>CBME執行現況 - 醫師 (I)</h3>
                 <div class="summary-boxes">
-                    <div class="summary-box">
+                    <div class="summary-box established">
                         <h3>已建立</h3>
                         <div class="count">13</div>
                         <div class="details">內科部、外科部、婦產部、急診醫學部…</div>
                     </div>
-                    <div class="summary-box">
+                    <div class="summary-box planning">
                         <h3>尚未建立 (規劃中)</h3>
                         <div class="count">10</div>
                         <div class="details">兒科部、泌尿外科、復健部、整形外科、精神醫學部、中醫部、解剖病理科、骨科部、眼科部、皮膚科</div>
                     </div>
-                    <div class="summary-box">
+                    <div class="summary-box no-plan">
                         <h3>無規劃</h3>
                         <div class="count">1</div>
                         <div class="details">職業醫學科 (待學會公告配合)</div>


### PR DESCRIPTION
## Summary
- keep "已建立", "尚未建立 (規劃中)", and "無規劃" on one row
- shrink the status boxes and use color to distinguish the three statuses

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b509b0db48321932cd2ff2fa87a38