### PR TITLE
Improve CBME headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,6 +461,18 @@
             text-align: left;
         }
 
+        .highlight-button {
+            display: inline-block;
+            background-color: var(--accent-blue-main);
+            color: var(--bg-white);
+            padding: 10px 20px;
+            border-radius: 8px;
+            margin: 40px auto 20px auto;
+            font-size: 1.4em;
+            font-weight: bold;
+            text-align: center;
+        }
+
         .cbme-table-container {
             overflow-x: auto;
             width: 100%;
@@ -1386,7 +1398,7 @@
             <div class="ccc-cbme-report">
                 <h2>CBME執行現況</h2>
 
-                <h3>CBME執行現況 - 醫師 (I)</h3>
+                <h3 class="highlight-button">醫師 (I)</h3>
                 <div class="summary-boxes">
                     <div class="summary-box">
                         <h3>已建立</h3>
@@ -1405,7 +1417,7 @@
                     </div>
                 </div>
 
-                <h3 class="section-title">CBME執行現況 - 醫師 (II)</h3>
+                <h3 class="highlight-button">醫師 (II)</h3>
                 <div class="cbme-table-container">
                     <table class="cbme-table">
                         <thead>
@@ -1443,7 +1455,7 @@
                     </table>
                 </div>
 
-                <h3 class="section-title">CBME執行現況 - 醫師 (III)</h3>
+                <h3 class="highlight-button">醫師 (III)</h3>
                 <div class="cbme-table-container">
                     <table class="cbme-table">
                         <thead>
@@ -1480,7 +1492,7 @@
                     </table>
                 </div>
 
-                <h3 class="section-title">CBME執行現況 - 醫事職類</h3>
+                <h3 class="highlight-button">醫事職類</h3>
                 <div class="cbme-table-container">
                     <table class="cbme-table">
                         <thead>


### PR DESCRIPTION
## Summary
- add `highlight-button` style for button-like headings
- style CBME sections using the new class and remove redundant prefixes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b54a39acc832193e85a4e595230da