### PR TITLE
Highlight competition details in Clinical Skills section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1530,8 +1530,8 @@
             <div class="clinical-team-group clinical-team-new">
                 <h3>新人組</h3>
                 <ul>
-                    <li><strong>競賽日期：</strong>114年9月13日(新人組第一場) 11:55-12:40</li>
-                    <li><strong>競賽地點：</strong>林口長庚醫院</li>
+                    <li class="highlight-info"><strong>競賽日期：</strong>114年9月13日(新人組第一場) 11:55-12:40</li>
+                    <li class="highlight-info"><strong>競賽地點：</strong>林口長庚醫院</li>
                     <li><strong>參賽人員：</strong>
                         <ul>
                             <li>一般科：郭家妤醫師</li>
@@ -1546,8 +1546,8 @@
             <div class="clinical-team-group clinical-team-critical">
                 <h3>急重症照護組</h3>
                 <ul>
-                    <li><strong>競賽日期：</strong>114年11月15日(急重症第三場)15:35-16:45</li>
-                    <li><strong>競賽地點：</strong>高雄醫學大學附設醫院</li>
+                    <li class="highlight-info"><strong>競賽日期：</strong>114年11月15日(急重症第三場)15:35-16:45</li>
+                    <li class="highlight-info"><strong>競賽地點：</strong>高雄醫學大學附設醫院</li>
                     <li><strong>參賽人員：</strong>
                         <ul>
                             <li>急診醫學部：秦郁涵醫師、陳韋廷醫師</li>


### PR DESCRIPTION
## Summary
- emphasise competition dates and locations in Clinical Skills section

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b63438660832196338c240fa7755e