### PR TITLE
Adjust clinical info block style

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,13 +241,14 @@
             font-size: 1.1em;
         }
         .highlight-info {
-            background-color: var(--accent-blue-main);
-            color: var(--bg-white);
+            background-color: var(--accent-blue-light); /* Lighter background for better readability */
+            color: var(--accent-blue-main); /* Dark blue text for clear contrast */
             padding: 12px 20px;
             border-radius: 8px;
             font-weight: bold;
             display: inline-block;
             margin: 10px 5px;
+            border: 2px solid var(--accent-blue-main); /* Add border to emphasize block */
             box-shadow: 0 2px 8px rgba(0,0,0,0.2);
             text-align: center;
             font-size: 1.1em;


### PR DESCRIPTION
## Summary
- adjust `.highlight-info` color scheme so competition date and location blocks are easier to read

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b661b92dc8321beea02f5d9ebade6