### PR TITLE
Add sub pages for awards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1103,7 +1103,13 @@ main
     <div id="sidebar">
         <div class="sidebar-header">醫學教育委員會<br>114年07月會議報告</div>
         <ul>
-            <li><a href="#awards" class="sidebar-link active">頒獎</a></li>
+            <li class="has-submenu">
+                <a href="#awards" class="sidebar-link active">頒獎</a>
+                <ul>
+                    <li><a href="#monthly-duty-award" class="sidebar-link sub-link">當月值班教學優秀獎</a></li>
+                    <li><a href="#narrative-award" class="sidebar-link sub-link">敘事醫學競賽獲獎</a></li>
+                </ul>
+            </li>
             <li><a href="#chairman-report" class="sidebar-link">主席報告</a></li>
             <li><a href="#last-meeting-followup" class="sidebar-link">上次會議追蹤</a></li>
             <li class="has-submenu">
@@ -1144,6 +1150,16 @@ main
                 <li>1-2月UGY學員回饋選出「當月值班教學優秀獎」</li>
                 <li>醫院敘事醫學系列競賽活動「醫療的瞬間・永恆的感動」短影音競賽及攝影競賽獲獎</li>
             </ul>
+        </div>
+
+        <div id="monthly-duty-award" class="page-content">
+            <h2>當月值班教學優秀獎</h2>
+            <p style="text-align: center; font-size: 1.2em; color: var(--primary-dark-text);">1-2月UGY學員回饋選出</p>
+        </div>
+
+        <div id="narrative-award" class="page-content">
+            <h2>敘事醫學競賽獲獎</h2>
+            <p style="text-align: center; font-size: 1.2em; color: var(--primary-dark-text);">醫院敘事醫學系列競賽活動「醫療的瞬間・永恆的感動」短影音競賽及攝影競賽獲獎</p>
         </div>
 
         <div id="chairman-report" class="page-content">


### PR DESCRIPTION
## Summary
- add nested subtabs under "頒獎" with links for monthly duty award and narrative medicine award
- add content sections for the new subtabs

## Testing
- `tidy -e index.html` *(fails: command not found)*
- `htmlhint index.html` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686b8112bff08321b448be6cead4506d