### PR TITLE
Set Noto Sans TC as default font

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>114年07月醫學教育委員會</title>
+    <!-- Load Noto Sans TC font with required weights -->
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
         /* Define a color palette using CSS variables based on the screenshot */
         :root {
@@ -23,7 +25,7 @@
         }
 
         body {
-            font-family: '微軟正黑體', 'Microsoft JhengHei', sans-serif;
+            font-family: 'Noto Sans TC', sans-serif;
             margin: 0;
             padding: 0;
             display: flex;


### PR DESCRIPTION
## Summary
- include Noto Sans TC from Google Fonts
- use Noto Sans TC as the default site font

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b8127e5a88321bf35aa10bd347216