### PR TITLE
Update narrative medicine award page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1193,10 +1193,11 @@
             margin-bottom: 10px;
             display: block;
         }
-        .award-card .work {
-            font-style: italic;
-            font-weight: 600;
+        .work {
+            font-weight: bold;
+            font-style: normal;
             margin-bottom: 8px;
+            text-align: center;
         }
         .award-card ul {
             list-style: none;
@@ -1206,6 +1207,15 @@
         }
         .award-card ul li {
             margin-bottom: 6px;
+        }
+        .third-place-list {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 10px;
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            text-align: center;
         }
         .honorable-section {
             margin-top: 20px;
@@ -1217,6 +1227,7 @@
             font-weight: 600;
         }
         .honorable-list {
+            overflow-x: hidden;
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
             gap: 20px;
@@ -1337,7 +1348,7 @@
                     <div class="award-card">
                         <div class="medal">🥈 第二名</div>
                         <div class="work work-blue">《縫隙之間，微光流轉》</div>
-                        <div class="author">程蕙倫／婦產部</div>
+                        <div class="author">程葦倫／婦產部</div>
                     </div>
                     <div class="award-card">
                         <div class="medal">🥉 第三名</div>
@@ -1348,12 +1359,12 @@
                 <div class="honorable-section">
                     <h4>佳作</h4>
                     <div class="honorable-list">
-                        <div class="honorable-card"><span class="honorable-index">1.</span> <span class="work work-green">《忙碌中停下腳步，記得溫度》</span><div class="author">方郁涵／9A</div></div>
-                        <div class="honorable-card"><span class="honorable-index">2.</span> <span class="work work-blue">《烈日下的那一口安心》</span><div class="author">李芯儀／健康促進組</div></div>
-                        <div class="honorable-card"><span class="honorable-index">3.</span> <span class="work work-red">《靜默中的專注》</span><div class="author">林志遠／藥劑部</div></div>
-                        <div class="honorable-card"><span class="honorable-index">4.</span> <span class="work work-green">《靜靜地～陪你走一段》</span><div class="author">黃詠琳／急診醫學部</div></div>
-                        <div class="honorable-card"><span class="honorable-index">5.</span> <span class="work work-blue">《在家也能被療癒。一雙手，撫平病痛，也撫慰人心》</span><div class="author">楊惠君／公共事務室</div></div>
-                        <div class="honorable-card"><span class="honorable-index">6.</span> <span class="work work-red">《前輩與新人》</span><div class="author">何承蔚／一般科</div></div>
+                        <div class="honorable-card"><span class="work work-green">《忙碌中停下腳步，記得溫度》</span><div class="author">方郁涵／9A</div></div>
+                        <div class="honorable-card"><span class="work work-blue">《烈日下的那一口安心》</span><div class="author">李芯儀／健康促進組</div></div>
+                        <div class="honorable-card"><span class="work work-red">《靜默中的專注》</span><div class="author">林志遠／藥劑部</div></div>
+                        <div class="honorable-card"><span class="work work-green">《靜靜地～陪你走一段》</span><div class="author">黃詠琳／急診醫學部</div></div>
+                        <div class="honorable-card"><span class="work work-blue">《在家也能被療癒，一雙手，撫平病痛，也撫慰人心》</span><div class="author">楊惠君／公共事務室</div></div>
+                        <div class="honorable-card"><span class="work work-red">《前輩與新人》</span><div class="author">何承蔚／一般科</div></div>
                     </div>
                 </div>
             </div>
@@ -1369,14 +1380,14 @@
                     <div class="award-card">
                         <div class="medal">🥈 第二名</div>
                         <ul>
-                            <li><span class="work work-blue">《護理的瞬間，永恆的感動》</span><div class="author">廖麗月／公共事務室</div></li>
-                            <li><span class="work work-red">《移動的溫柔：從影像開始的守護》</span><div class="author">黃美蘭／放射診斷科</div></li>
+                            <li><span class="work work-blue">《護理的瞬間–永恆的感動》</span><div class="author">廖麗月／公共事務室</div></li>
+                            <li><span class="work work-red">《移動的溫柔–從影像開始的守護》</span><div class="author">黃美蘭／放射診斷科</div></li>
                         </ul>
                     </div>
                     <div class="award-card">
                         <div class="medal">🥉 第三名</div>
-                        <ul>
-                            <li><span class="work work-green">《重生的祝福》</span><div class="author">顏旻萱／8B</div></li>
+                        <ul class="third-place-list">
+                            <li><span class="work work-green">《重生的祝福》</span><div class="author">顏旻萱／8B病房</div></li>
                             <li><span class="work work-blue">《一樣的中秋節》</span><div class="author">楊書瑜／復健部</div></li>
                             <li><span class="work work-red">《被記住的溫柔》</span><div class="author">黃淑芬／藥劑部</div></li>
                         </ul>
@@ -1385,11 +1396,11 @@
                 <div class="honorable-section">
                     <h4>佳作</h4>
                     <div class="honorable-list">
-                        <div class="honorable-card"><span class="honorable-index">1.</span> <span class="work work-green">《友善醫療：從同理開始》</span><div class="author">杜漢祥／品質管理中心</div></div>
-                        <div class="honorable-card"><span class="honorable-index">2.</span> <span class="work work-blue">《兩塊錢的信封袋，跨越時空的念想》</span><div class="author">陳乃蓁、蘇婉淳、蔡雅雯／院長室 研究發展組</div></div>
-                        <div class="honorable-card"><span class="honorable-index">3.</span> <span class="work work-red">《從沉默裡，「刮」出微光》</span><div class="author">陳璟綺／復健部</div></div>
-                        <div class="honorable-card"><span class="honorable-index">4.</span> <span class="work work-green">《有時候，一句話，就能讓人安心》</span><div class="author">黃淑芬／藥劑部</div></div>
-                        <div class="honorable-card"><span class="honorable-index">5.</span> <span class="work work-blue">《生命微光～早產兒生命之旅》</span><div class="author">林品吟、李晴玉、陶菁／護理部</div></div>
+                        <div class="honorable-card"><span class="work work-green">《友善醫療：從同理開始》</span><div class="author">杜漢祥／品質管理中心</div></div>
+                        <div class="honorable-card"><span class="work work-blue">《兩塊錢的信封袋，跨越時空的念想》</span><div class="author">陳乃菁、蘇婉淳、蔡雅雯／院長室 研究發展組</div></div>
+                        <div class="honorable-card"><span class="work work-red">《從沉默裡，「刮」出微光》</span><div class="author">陳璟綺／復健部</div></div>
+                        <div class="honorable-card"><span class="work work-green">《有時候，一句話，就能讓人安心》</span><div class="author">黃淑芬／藥劑部</div></div>
+                        <div class="honorable-card"><span class="work work-blue">《生命微光～早產兒生命之旅》</span><div class="author">林品吟、李晴玉、陶菁／護理部</div></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- update award titles and names on narrative medicine award section
- style works as bold centered text
- place third place video award winners in a 3-column grid
- remove numbering from honorable mention lists and tweak grid overflow handling

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686baf49d4a08321b3254639c1756c92