### PR TITLE
Adjust CBME report page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>114年07月醫學教育委員會</title>
     <!-- Load Noto Sans TC font with required weights -->
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
     <style>
         /* Define a color palette using CSS variables based on the screenshot */
         :root {
@@ -22,6 +23,7 @@
             --success-green: #28a745; /* Standard green for success */
             --danger-red: #dc3545; /* Standard red for danger */
             --warning-yellow: #ffc107; /* Standard yellow for warnings */
+            --header-green: #556B2F; /* Olive green for table headers */
         }
 
         body,
@@ -459,20 +461,21 @@
             margin-bottom: 30px;
             border-bottom: 3px solid var(--accent-blue-main);
             padding-bottom: 15px;
+            text-align: left;
         }
         .summary-boxes {
             display: flex;
-            justify-content: space-around;
+            justify-content: space-between;
             gap: 25px;
             margin-bottom: 40px;
-            flex-wrap: nowrap; /* keep all boxes on the same row */
+            flex-wrap: wrap;
         }
         .summary-box {
             background-color: var(--accent-blue-light); /* Light blue background */
             border-radius: 12px;
             padding: 20px 25px;
-            flex: 1 0 30%;
-            max-width: 30%;
+            flex: 1 1 33%;
+            max-width: 33%;
             box-shadow: 0 4px 15px rgba(0,0,0,0.1);
             text-align: center;
             transition: transform 0.2s ease-in-out;
@@ -512,19 +515,18 @@
         }
 
         .highlight-button {
-            display: inline-block;
+            display: block;
             background-color: var(--accent-blue-main);
             color: var(--bg-white);
             padding: 10px 20px;
             border-radius: 8px;
-            margin: 40px auto 20px auto;
+            margin: 40px 0 20px 0;
             font-size: 1.4em;
             font-weight: bold;
-            text-align: center;
+            text-align: left;
         }
 
         .cbme-table-container {
-            overflow-x: auto;
             width: 100%;
             margin-bottom: 30px;
         }
@@ -532,18 +534,19 @@
             width: 100%;
             border-collapse: collapse;
             font-size: 0.95em;
-            min-width: 800px;
-            border-radius: 8px;
+            border-radius: 0;
             overflow: hidden;
         }
         .cbme-table th, .cbme-table td {
             border: 1px solid var(--border-gray);
             padding: 12px;
-            text-align: left;
+            text-align: center;
             vertical-align: middle;
+            white-space: normal;
+            word-break: break-word;
         }
         .cbme-table th {
-            background-color: var(--accent-blue-main);
+            background-color: var(--header-green);
             color: var(--bg-white);
             font-weight: bold;
         }
@@ -1805,7 +1808,7 @@
             <div class="ccc-cbme-report">
                 <h2>CBME執行現況</h2>
 
-                <h3 class="highlight-button">醫師 (I)</h3>
+                <h3 class="highlight-button">醫師</h3>
                 <div class="summary-boxes">
                     <div class="summary-box">
                         <h3>已建立</h3>
@@ -1824,15 +1827,14 @@
                     </div>
                 </div>
 
-                <h3 class="highlight-button">醫師 (II)</h3>
                 <div class="cbme-table-container">
                     <table class="cbme-table">
                         <thead>
                             <tr>
                                 <th>科部</th>
                                 <th>CCC推動執行者</th>
-                                <th colspan="2">CCC制度建立</th>
-                                <th colspan="3">CCC評核月</th>
+                                <th colspan="3">CCC制度建立</th>
+                                <th colspan="2">CCC評核月</th>
                             </tr>
                             <tr>
                                 <th></th>
@@ -1862,15 +1864,14 @@
                     </table>
                 </div>
 
-                <h3 class="highlight-button">醫師 (III)</h3>
                 <div class="cbme-table-container">
                     <table class="cbme-table">
                         <thead>
                             <tr>
                                 <th>科部</th>
                                 <th>CCC推動執行者</th>
-                                <th colspan="2">CCC制度建立</th>
-                                <th colspan="3">CCC評核月</th>
+                                <th colspan="3">CCC制度建立</th>
+                                <th colspan="2">CCC評核月</th>
                             </tr>
                             <tr>
                                 <th></th>


### PR DESCRIPTION
## Summary
- align CBME headline and buttons to the left
- make summary boxes equal width
- cleanup table headers and colors
- drop extra doctor toggle buttons
- include Tailwind for utility classes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bc5cffd488321aa5a95691ece4bdf