### PR TITLE
Fix layout for second place video awards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1192,7 +1192,7 @@
             padding: 20px;
             flex: 1 1 auto;
             min-width: 250px;
-            width: fit-content;
+            width: 260px; /* Consistent width for all award cards */
             text-align: center;
         }
         .award-card .medal {
@@ -1217,6 +1217,15 @@
         }
         .award-card ul li {
             margin-bottom: 6px;
+        }
+        .second-place-list li {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            margin-bottom: 10px; /* Uniform spacing between items */
+        }
+        .second-place-list li:last-child {
+            margin-bottom: 0;
         }
         .third-place-grid {
             display: flex;


### PR DESCRIPTION
## Summary
- maintain consistent card width across awards
- center each entry in the second-place block
- keep uniform spacing between entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bc605bc348321a3b30b0edcca3b2e