### PR TITLE
Fix alignment for 2nd place video entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,9 +1214,21 @@
         }
         .second-place-list {
             text-align: center;
+            padding: 0;
+            margin: 0;
         }
         .award-card ul li {
             margin-bottom: 6px;
+        }
+        .second-place-list li {
+            list-style: none;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+        .second-place-list li:last-child {
+            margin-bottom: 0;
         }
         .third-place-grid {
             display: flex;


### PR DESCRIPTION
## Summary
- center second place list items on the short video awards section
- ensure even vertical spacing between entries

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686bcaf7502c83219b9dbfcb598eea3c