### PR TITLE
Fix CBME table headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1837,14 +1837,12 @@
                     <table class="cbme-table">
                         <thead>
                             <tr>
-                                <th>科部</th>
-                                <th>CCC推動執行者</th>
+                                <th rowspan="2" style="text-align:center;">科部</th>
+                                <th rowspan="2" style="text-align:center;">CCC推動執行者</th>
                                 <th colspan="3">CCC制度建立</th>
                                 <th rowspan="2">CCC評核月</th>
                             </tr>
                             <tr>
-                                <th></th>
-                                <th></th>
                                 <th>有</th>
                                 <th>無</th>
                                 <th>書面</th>
@@ -1872,14 +1870,12 @@
                     <table class="cbme-table">
                         <thead>
                             <tr>
-                                <th>科部</th>
-                                <th>CCC推動執行者</th>
+                                <th rowspan="2" style="text-align:center;">科部</th>
+                                <th rowspan="2" style="text-align:center;">CCC推動執行者</th>
                                 <th colspan="3">CCC制度建立</th>
                                 <th rowspan="2">CCC評核月</th>
                             </tr>
                             <tr>
-                                <th></th>
-                                <th></th>
                                 <th>有</th>
                                 <th>無</th>
                                 <th>書面</th>
@@ -1908,7 +1904,7 @@
                         <thead>
                             <tr>
                                 <th>醫事職類</th>
-                                <th>Milestones／EPAs導入並應用</th>
+                                <th>Milestone／EPAs導入並應用</th>
                                 <th>學會／全聯會公版建置</th>
                                 <th>CCC 委員會成立並運行</th>
                                 <th>備註</th>


### PR DESCRIPTION
## Summary
- adjust milestone column header wording
- merge header cells for `科部` and `CCC推動執行者` columns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bd71eda5883219aaf64397fe87e25