### PR TITLE
Update monthly award page styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1203,6 +1203,10 @@
             width: fit-content;
             text-align: center;
         }
+        /* Pastel backgrounds for monthly award cards */
+        .award-card.march { background-color: #FFF7E8; }
+        .award-card.april { background-color: #E6F7FF; }
+        .award-card.may   { background-color: #F0E8FF; }
         .award-card .medal {
             font-size: 2em;
             margin-bottom: 10px;
@@ -1395,23 +1399,23 @@
             <h2>114年3–5月當月值班教學優秀獎</h2>
             <p style="text-align: center; font-size: 1.2em; color: var(--primary-dark-text);">UGY學員回饋選出</p>
             <div class="award-card-container">
-                <div class="award-card">
+                <div class="award-card march">
                     <div class="award-month">3月</div>
                     <div>一般科（PGY1）：孫懷奇醫師</div>
                     <div>一般科（PGY2）：何信賢醫師</div>
                 </div>
-                <div class="award-card">
+                <div class="award-card april">
                     <div class="award-month">4月</div>
                     <div>家庭醫學部（LR1）：吳哲嘉醫師</div>
                     <div>一般科（PGY2）：吳展誌醫師</div>
                 </div>
-                <div class="award-card">
+                <div class="award-card may">
                     <div class="award-month">5月</div>
                     <div>一般科（PGY1）：林柏成醫師</div>
                     <div>一般科（PGY2）：魏國唐醫師</div>
-                    <div class="award-note" style="text-align: right;">獎勵金每人2,000元</div>
                 </div>
             </div>
+            <div class="award-note" style="text-align: right;">獎勵金每人2,000元</div>
             <button id="monthly-music-btn" class="music-button" title="播放頒獎音樂">♫</button>
         </div>
 


### PR DESCRIPTION
## Summary
- add pastel backgrounds for March, April and May award blocks
- move reward note below award cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c7c365a448321925f34bd10865a33