### PR TITLE
Fix award note alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1221,8 +1221,11 @@
         .award-note {
             font-size: 0.85em;
             color: var(--accent-blue-main);
-            text-align: left;
+            text-align: right;
             margin-top: 10px;
+            max-width: 900px;
+            margin-left: auto;
+            margin-right: auto;
         }
         .work {
             font-weight: bold;
@@ -1415,7 +1418,7 @@
                     <div>一般科（PGY2）：魏國唐醫師</div>
                 </div>
             </div>
-            <div class="award-note" style="text-align: right;">獎勵金每人2,000元</div>
+            <div class="award-note">獎勵金每人2,000元</div>
             <button id="monthly-music-btn" class="music-button" title="播放頒獎音樂">♫</button>
         </div>
 


### PR DESCRIPTION
## Summary
- align the "獎勵金每人2,000元" note with the May award card
- refactor inline note styling into CSS and match card width

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c8492eaa88321a3efccb9ca55c1b2