### PR TITLE
Disable autoplay of award music from main tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -2128,6 +2128,7 @@
         // 將 let 改為 var 以避免重複宣告錯誤
         var awardsAudio = null;
         var isAudioPlaying = false;
+        var suppressAwardAudio = false; // flag to control autoplay when switching pages
 
         function initializeAwardsAudio() {
             if (!awardsAudio) {
@@ -2208,7 +2209,10 @@
 
                 // 音頻播放邏輯
                 if (id === 'awards') {
-                    playAwardsFanfare();
+                    if (!suppressAwardAudio) {
+                        playAwardsFanfare();
+                    }
+                    suppressAwardAudio = false; // reset after handling
                 } else {
                     stopAwardsFanfare();
                 }
@@ -2218,6 +2222,12 @@
                 link.addEventListener('click', function(e) {
                     e.preventDefault(); // 阻止連結的預設行為 (跳轉)
                     const targetId = this.getAttribute('href').substring(1); // 取得連結的hash值 (不含#)
+
+                    // 如果點擊的是「壹、頒獎」頁籤，避免自動播放音樂
+                    if (targetId === 'awards') {
+                        suppressAwardAudio = true;
+                    }
+
                     history.pushState(null, '', `#${targetId}`); // 更新URL hash
                     showPage(targetId);
 


### PR DESCRIPTION
## Summary
- prevent audio from automatically playing when clicking the "壹、頒獎" sidebar tab
- introduce a flag `suppressAwardAudio` to control autoplay behavior

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686d919b02608321942c236a4e73c320