### PR TITLE
Update award page visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -1218,6 +1218,7 @@
             font-size: 2em;
             margin-bottom: 10px;
             display: block;
+            font-weight: 600; /* Match "佳作" title style */
         }
         .award-month {
             font-size: 1.4em;
@@ -1290,6 +1291,10 @@
             text-align: center;
             font-weight: 600;
         }
+        /* Unified color for honorable mention titles */
+        .honorable-section .work {
+            color: #6d4c41; /* Neutral tone distinct from medal colors */
+        }
         .honorable-list {
             overflow-x: hidden;
             display: grid;
@@ -1321,7 +1326,6 @@
         .work-red  { color: #C62828; }
 
         .author { color: #000000; }
- main
         /* Footer style */
         .page-footer {
             position: absolute;
@@ -1547,7 +1551,6 @@
 
                         <div class="author">吳曉琪／教學中心</div>
                     </div>
- main
                     <div class="award-card">
                         <div class="medal">🥈 第二名</div>
                         <ul class="second-place-list">


### PR DESCRIPTION
## Summary
- unify medal heading style with honorable mention titles
- give honorable mention titles a consistent color
- remove stray `main` text from short video awards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d9233342483219b0c3aff8cf1b093