### PR TITLE
Update award colors and badge style

### DIFF
--- a/index.html
+++ b/index.html
@@ -1293,7 +1293,7 @@
         }
         /* Unified color for honorable mention titles */
         .honorable-section .work {
-            color: #6d4c41; /* Neutral tone distinct from medal colors */
+            color: #996633; /* Deep golden brown for honorable mentions */
         }
         .honorable-list {
             overflow-x: hidden;
@@ -1324,19 +1324,24 @@
         .work-green { color: #2E7D32; }
         .work-blue { color: #1565C0; }
         .work-red  { color: #C62828; }
+        /* New ranking color rules */
+        .first-place { color: #C62828; }
+        .second-place { color: #1565C0; }
+        .third-place { color: #2E7D32; }
+        .honorable { color: #996633; }
 
 
         .author { color: #000000; }
         .ai-collab-badge {
-            background-color: var(--accent-blue-main);
-            color: #fff;
+            background-color: #FF5722;
+            color: #FFFFFF;
             padding: 4px 10px;
-            border-radius: 6px;
+            border-radius: 8px;
             margin-top: 0.5rem;
             display: inline-block;
             font-weight: bold;
+            font-size: 1em;
         }
- main
         /* Footer style */
 
         .page-footer {
@@ -1526,29 +1531,29 @@
                 <div class="award-card-container">
                     <div class="award-card">
                         <div class="medal">🥇 第一名</div>
-                        <div class="work work-green">《一瞬之光～靜默的專注》</div>
+                        <div class="work first-place">《一瞬之光～靜默的專注》</div>
                         <div class="author">廖麗月／公共事務室</div>
                     </div>
                     <div class="award-card">
                         <div class="medal">🥈 第二名</div>
-                        <div class="work work-blue">《縫隙之間，微光流轉》</div>
+                        <div class="work second-place">《縫隙之間，微光流轉》</div>
                         <div class="author">程葦倫／婦產部</div>
                     </div>
                     <div class="award-card">
                         <div class="medal">🥉 第三名</div>
-                        <div class="work work-red">《口罩遮不住她的溫柔，眼神藏不住那份堅定的守護》</div>
+                        <div class="work third-place">《口罩遮不住她的溫柔，眼神藏不住那份堅定的守護》</div>
                         <div class="author">楊惠君／公共事務室</div>
                     </div>
                 </div>
                 <div class="honorable-section">
                     <h4>🏅 佳作</h4>
                     <div class="honorable-list">
-                        <div class="honorable-card"><span class="work work-green">《忙碌中停下腳步，記得溫度》</span><div class="author">方郁涵／9A病房</div></div>
-                        <div class="honorable-card"><span class="work work-blue">《烈日下的那一口安心》</span><div class="author">李芯儀／健康促進組</div></div>
-                        <div class="honorable-card"><span class="work work-red">《靜默中的專注》</span><div class="author">林志遠／藥劑部</div></div>
-                        <div class="honorable-card"><span class="work work-green">《靜靜地～陪你走一段》</span><div class="author">黃詠琳／急診醫學部</div></div>
-                        <div class="honorable-card"><span class="work work-blue">《在家也能被療癒，一雙手,<br>撫平病痛，也撫慰人心》</span><div class="author">楊惠君／公共事務室</div></div>
-                        <div class="honorable-card"><span class="work work-red">《前輩與新人》</span><div class="author">何承蔚／一般科</div></div>
+                    <div class="honorable-card"><span class="work honorable">《忙碌中停下腳步，記得溫度》</span><div class="author">方郁涵／9A病房</div></div>
+                    <div class="honorable-card"><span class="work honorable">《烈日下的那一口安心》</span><div class="author">李芯儀／健康促進組</div></div>
+                    <div class="honorable-card"><span class="work honorable">《靜默中的專注》</span><div class="author">林志遠／藥劑部</div></div>
+                    <div class="honorable-card"><span class="work honorable">《靜靜地～陪你走一段》</span><div class="author">黃詠琳／急診醫學部</div></div>
+                    <div class="honorable-card"><span class="work honorable">《在家也能被療癒，一雙手,<br>撫平病痛，也撫慰人心》</span><div class="author">楊惠君／公共事務室</div></div>
+                    <div class="honorable-card"><span class="work honorable">《前輩與新人》</span><div class="author">何承蔚／一般科</div></div>
                     </div>
                 </div>
             </div>
@@ -1559,38 +1564,37 @@
                     <div class="award-card">
                         <div class="medal">🥇 第一名</div>
 
-                        <div class="work work-green">《那一刻，我被理解了》</div>
+                        <div class="work first-place">《那一刻，我被理解了》</div>
 
-                        
+
                         <div class="author">吳曉琪／教學中心</div>
                         <div class="ai-collab-badge">🎖AI協作特別獎</div>
                     </div>
-main
                     <div class="award-card">
 
                         <div class="medal">🥈 第二名</div>
                         <ul class="second-place-list">
-                            <li><span class="work work-blue">《護理的瞬間–永恆的感動》</span><div class="author">廖麗月／公共事務室</div></li>
-                            <li><span class="work work-red">《移動的溫柔–從影像開始的守護》</span><div class="author">黃美蘭／放射診斷科</div></li>
+                            <li><span class="work second-place">《護理的瞬間–永恆的感動》</span><div class="author">廖麗月／公共事務室</div></li>
+                            <li><span class="work second-place">《移動的溫柔–從影像開始的守護》</span><div class="author">黃美蘭／放射診斷科</div></li>
                         </ul>
                     </div>
                     <div class="award-card">
                         <div class="medal">🥉 第三名</div>
                         <div class="third-place-grid">
-                            <div class="third-place-item"><span class="work work-green">《重生的祝福》</span><div class="author">顏旻萱／8B病房</div></div>
-                            <div class="third-place-item"><span class="work work-blue">《一樣的中秋節》</span><div class="author">楊書瑜／復健部</div></div>
-                            <div class="third-place-item"><span class="work work-red">《被記住的溫柔》</span><div class="author">黃淑芬／藥劑部</div></div>
+                            <div class="third-place-item"><span class="work third-place">《重生的祝福》</span><div class="author">顏旻萱／8B病房</div></div>
+                            <div class="third-place-item"><span class="work third-place">《一樣的中秋節》</span><div class="author">楊書瑜／復健部</div></div>
+                            <div class="third-place-item"><span class="work third-place">《被記住的溫柔》</span><div class="author">黃淑芬／藥劑部</div></div>
                         </div>
                     </div>
                 </div>
                 <div class="honorable-section">
                     <h4>🏅 佳作</h4>
                     <div class="honorable-list">
-                        <div class="honorable-card"><span class="work work-green">《友善醫療：從同理開始》</span><div class="author">杜漢祥／品質管理中心</div></div>
-                        <div class="honorable-card"><span class="work work-blue">《兩塊錢的信封袋，跨越時空的念想》</span><div class="author">陳乃菁、蘇婉淳、蔡雅雯<br>／院長室 研究發展組</div></div>
-                        <div class="honorable-card"><span class="work work-red">《從沉默裡，「刮」出微光》</span><div class="author">陳璟綺／復健部</div></div>
-                        <div class="honorable-card"><span class="work work-green">《有時候，一句話，就能讓人安心》</span><div class="author">黃淑芬／藥劑部</div></div>
-                        <div class="honorable-card"><span class="work work-blue">《生命微光～早產兒生命之旅》</span><div class="author">林品吟、李晴玉、陶菁／護理部</div></div>
+                        <div class="honorable-card"><span class="work honorable">《友善醫療：從同理開始》</span><div class="author">杜漢祥／品質管理中心</div></div>
+                        <div class="honorable-card"><span class="work honorable">《兩塊錢的信封袋，跨越時空的念想》</span><div class="author">陳乃菁、蘇婉淳、蔡雅雯<br>／院長室 研究發展組</div></div>
+                        <div class="honorable-card"><span class="work honorable">《從沉默裡，「刮」出微光》</span><div class="author">陳璟綺／復健部</div></div>
+                        <div class="honorable-card"><span class="work honorable">《有時候，一句話，就能讓人安心》</span><div class="author">黃淑芬／藥劑部</div></div>
+                        <div class="honorable-card"><span class="work honorable">《生命微光～早產兒生命之旅》</span><div class="author">林品吟、李晴玉、陶菁／護理部</div></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- revise colors for award titles based on ranking
- style AI collaboration badge with bright orange
- clean stray text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d95d94df88321b821d6591dea9cb3