### PR TITLE
Add camp section with masked background imagery

### DIFF
--- a/camp.html
+++ b/camp.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Camp Section</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: "Noto Sans TC", "Microsoft JhengHei", sans-serif;
+            background-color: #f5f5f5;
+            color: #333;
+        }
+        .section-cards {
+            position: relative;
+            padding: 60px 20px;
+            background-image: url('images/許文龍.jpg');
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+        .section-cards::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: rgba(255, 255, 255, 0.8);
+        }
+        .section-cards > * {
+            position: relative;
+            z-index: 1;
+        }
+        .section-cards h2 {
+            margin: 0;
+            font-size: 2rem;
+            text-align: center;
+        }
+        .cards-wrapper {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 20px;
+        }
+        .card {
+            background-color: rgba(255, 255, 255, 0.9);
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 16px 24px rgba(0, 0, 0, 0.12);
+        }
+        .card h3 {
+            margin-top: 0;
+            margin-bottom: 12px;
+            font-size: 1.3rem;
+            color: #1E88E5;
+        }
+        .card p {
+            margin: 0;
+            line-height: 1.6;
+        }
+        @media (max-width: 600px) {
+            .section-cards {
+                padding: 40px 16px;
+            }
+            .section-cards h2 {
+                font-size: 1.6rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <section class="section-cards">
+        <h2>營隊亮點活動</h2>
+        <div class="cards-wrapper">
+            <article class="card">
+                <h3>創意工作坊</h3>
+                <p>透過跨領域師資帶領，激發學員創意思考與團隊協作，打造專屬營隊紀念作品。</p>
+            </article>
+            <article class="card">
+                <h3>戶外探索課程</h3>
+                <p>結合生態導覽與冒險教育，在大自然中培養問題解決能力與韌性。</p>
+            </article>
+            <article class="card">
+                <h3>成果分享會</h3>
+                <p>邀請家長與社區夥伴參與，展示學員學習成果與團隊精神，擴散營隊能量。</p>
+            </article>
+        </div>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `camp.html` page containing the section cards layout
- apply the requested background image styling with centered, covered image and white opacity mask

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911dc3eb59c832186fc89a58227ba2a)